### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <netty-all.version>4.1.6.Final</netty-all.version>
+        <netty-all.version>4.1.44.Final</netty-all.version>
         <lombok.version>1.16.12</lombok.version>
         <fastjson.version>1.2.29</fastjson.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.1.6.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)


### What did I do？
Upgrade io.netty:netty-all from 4.1.6.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS